### PR TITLE
Add prompt for CI

### DIFF
--- a/lib/Base.js
+++ b/lib/Base.js
@@ -83,14 +83,13 @@ module.exports = generators.Base.extend({
     }, {
       when: !this.options.ci,
       type: 'checkbox',
-      name: 'list',
+      name: 'ci',
       message: 'Which Continuous Integration platform do you want?',
       choices: [
         {name: 'Travis', value: 'travis'},
         {name: 'CircleCi', value: 'circleci'},
         {name: 'Jenkins (with Dockerfile)', value: 'jenkins'},
-        {name: 'Wercker', value: 'wercker'},
-        {name: 'None', value: 'none'}
+        {name: 'Wercker', value: 'wercker'}
       ]
     }];
 

--- a/lib/Base.js
+++ b/lib/Base.js
@@ -13,6 +13,7 @@ module.exports = generators.Base.extend({
     this.option('modules', {type: String, required: false});
     this.option('css', {type: String, required: false});
     this.option('js', {type: String, required: false});
+    this.option('ci', {type: String, required: false});
     // this.option('html', {type: String, required: false });
   },
 
@@ -79,6 +80,18 @@ module.exports = generators.Base.extend({
     //   choices: [
     //     {name: 'HTML', value: 'html' }
     //   ]
+    }, {
+      when: !this.options.ci,
+      type: 'checkbox',
+      name: 'list',
+      message: 'Which Continuous Integration platform do you want?',
+      choices: [
+        {name: 'Travis', value: 'travis'},
+        {name: 'CircleCi', value: 'circleci'},
+        {name: 'Jenkins (with Dockerfile)', value: 'jenkins'},
+        {name: 'Wercker', value: 'wercker'},
+        {name: 'None', value: 'none'}
+      ]
     }];
 
     return this.prompt(prompts).then(props => {

--- a/test/lib/Base/Base.constructor.js
+++ b/test/lib/Base/Base.constructor.js
@@ -16,13 +16,14 @@ test.before(() => {
   require('../../../lib/Base');
 });
 
-test(`Call 'this.option' 4 times with correct parameters`, () => {
+test(`Call 'this.option' 5 times with correct parameters`, () => {
   context.option = () => {};
   const spy = chai.spy.on(context, 'option');
   context.constructor();
-  expect(spy).to.have.been.called.exactly(4);
+  expect(spy).to.have.been.called.exactly(5);
   expect(spy).to.have.been.called.with('framework');
   expect(spy).to.have.been.called.with('modules');
   expect(spy).to.have.been.called.with('css');
   expect(spy).to.have.been.called.with('js');
+  expect(spy).to.have.been.called.with('ci');
 });


### PR DESCRIPTION
I thought it would be useful that Fountain could generate default CI configuration for users.
So, I added prompt to choose which CI :
- Travis
- Jenkins (with a docker configuration base on [alpine-nodejs](https://github.com/mhart/alpine-node) image, for a light size)
- Wercker
- Circle-CI

Link to [this PR](https://github.com/FountainJS/generator-fountain-gulp/pull/48)
