### PR TITLE
Force JS files to checkout as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.js text eol=lf


### PR DESCRIPTION
Currently if you checkout the code on Windows the JS files will have CRLF
and will automatically fail in ESLint when running 'npm test'